### PR TITLE
add config for partition timestamp field name

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
@@ -61,6 +61,7 @@ public final class GcsSinkConfig extends AivenCommonConfig {
     public static final String FILE_MAX_RECORDS = "file.max.records";
     public static final String FILE_NAME_TIMESTAMP_TIMEZONE = "file.name.timestamp.timezone";
     public static final String FILE_NAME_TIMESTAMP_SOURCE = "file.name.timestamp.source";
+    public static final String PARTITION_FIELD_NAME = "partition.field.name";
 
     public static final String FORMAT_OUTPUT_FIELDS_CONFIG = "format.output.fields";
     public static final String FORMAT_OUTPUT_FIELDS_VALUE_ENCODING_CONFIG = "format.output.fields.value.encoding";
@@ -382,6 +383,19 @@ public final class GcsSinkConfig extends AivenCommonConfig {
             fileGroupCounter,
             ConfigDef.Width.SHORT,
             FILE_NAME_TIMESTAMP_SOURCE
+        );
+
+        configDef.define(
+            PARTITION_FIELD_NAME,
+            ConfigDef.Type.STRING,
+            null,
+            null,
+            ConfigDef.Importance.MEDIUM,
+            "Specifies the underlying timestamp field to use for filename partitioning.",
+            GROUP_FILE,
+            fileGroupCounter,
+            ConfigDef.Width.SHORT,
+            PARTITION_FIELD_NAME
         );
 
     }

--- a/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
+++ b/src/test/java/io/aiven/kafka/connect/gcs/config/GcsSinkConfigTest.java
@@ -1001,6 +1001,18 @@ final class GcsSinkConfigTest {
         assertEquals(TimestampSource.WallclockTimestampSource.class, c.getFilenameTimestampSource().getClass());
     }
 
+    @Test
+    void validationPassesPartitionedFieldName() {
+        final Map<String, String> properties = Map.of(
+            "gcs.bucket.name", "test-bucket",
+            "file.name.timestamp.timezone", "Europe/Berlin",
+            "partition.field.name", "event_occurrence_timestamp"
+
+        );
+
+        assertConfigDefValidationPasses(properties);
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"jsonl", "json", "csv"})
     void supportedFormatTypeConfig(final String formatType) {


### PR DESCRIPTION
Mini PR so that the GCS Connector can support the changes in this PR: https://github.com/aiven/commons-for-apache-kafka-connect/pull/70