### PR TITLE
Remove mavenLocal repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ plugins {
 group = "io.aiven"
 
 repositories {
-    mavenLocal()
     mavenCentral()
     // For kafka-avro-serializer and kafka-connect-avro-converter
     maven {


### PR DESCRIPTION
Using `mavenLocal` has its problems and it´s not recommended to use it.

https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:case-for-maven-local

The other connectors such as https://github.com/aiven/jdbc-connector-for-apache-kafka/blob/master/build.gradle don´t have it.