### PR TITLE
chore: upgrade confluent platform dependencies version to 7.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ ext {
     kafkaVersion = "1.1.0"
     // Compatible with Kafka version:
     // https://docs.confluent.io/current/installation/versions-interoperability.html
-    confluentPlatformVersion = "4.1.4"
+    confluentPlatformVersion = "7.2.1"
     aivenConnectCommonsVersion = "0.8.2"
     testcontainersVersion = "1.17.3"
     slf4jVersion = "1.7.36"


### PR DESCRIPTION
Use the same version as the the commons-for-apache-kafka-connect for confluent platform avro libraries 
https://github.com/aiven/commons-for-apache-kafka-connect/blob/master/build.gradle#L88
Should fix #189.