### PR TITLE
Fix integration tests

### DIFF
--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/AvroIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/AvroIntegrationTest.java
@@ -43,7 +43,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -52,12 +51,7 @@ final class AvroIntegrationTest extends AbstractIntegrationTest {
     private static final String CONNECTOR_NAME = "aiven-gcs-sink-connector";
 
     @Container
-    private final KafkaContainer kafka = new KafkaContainer()
-            // Expose both Kafka ports:
-            // 9092 can be used inside Docker network (by the Schema Registry container)
-            .withExposedPorts(KafkaContainer.KAFKA_PORT, 9092)
-            .withNetwork(Network.newNetwork())
-            .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+    private final KafkaContainer kafka = createKafkaContainer();
 
     @Container
     private final SchemaRegistryContainer schemaRegistry = new SchemaRegistryContainer(kafka);

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/AvroParquetIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/AvroParquetIntegrationTest.java
@@ -51,7 +51,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.containers.KafkaContainer;
-import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -61,12 +60,7 @@ final class AvroParquetIntegrationTest extends AbstractIntegrationTest {
     private static final String CONNECTOR_NAME = "aiven-gcs-sink-connector-parquet";
 
     @Container
-    private final KafkaContainer kafka = new KafkaContainer()
-            // Expose both Kafka ports:
-            // 9092 can be used inside Docker network (by the Schema Registry container)
-            .withExposedPorts(KafkaContainer.KAFKA_PORT, 9092)
-            .withNetwork(Network.newNetwork())
-            .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+    private final KafkaContainer kafka = createKafkaContainer();
 
     @Container
     private final SchemaRegistryContainer schemaRegistry = new SchemaRegistryContainer(kafka);

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/IntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/IntegrationTest.java
@@ -60,7 +60,7 @@ final class IntegrationTest extends AbstractIntegrationTest {
     private static final String CONNECTOR_NAME = "aiven-gcs-sink-connector";
 
     @Container
-    private final KafkaContainer kafka = new KafkaContainer().withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+    private final KafkaContainer kafka = createKafkaContainer();
 
     private AdminClient adminClient;
     private KafkaProducer<byte[], byte[]> producer;

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/ParquetIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/ParquetIntegrationTest.java
@@ -60,7 +60,7 @@ final class ParquetIntegrationTest extends AbstractIntegrationTest {
     private static final String CONNECTOR_NAME = "aiven-gcs-sink-connector-parquet";
 
     @Container
-    private final KafkaContainer kafka = new KafkaContainer().withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+    private final KafkaContainer kafka = createKafkaContainer();
 
     private AdminClient adminClient;
     private KafkaProducer<byte[], byte[]> producer;

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/SchemaRegistryContainer.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/SchemaRegistryContainer.java
@@ -16,6 +16,9 @@
 
 package io.aiven.kafka.connect.gcs;
 
+import java.util.List;
+
+import com.github.dockerjava.api.model.Ulimit;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.Base58;
@@ -39,6 +42,9 @@ final class SchemaRegistryContainer extends GenericContainer<SchemaRegistryConta
 
         withExposedPorts(SCHEMA_REGISTRY_PORT);
         withEnv("SCHEMA_REGISTRY_HOST_NAME", "localhost");
+
+        withCreateContainerCmdModifier(
+                cmd -> cmd.getHostConfig().withUlimits(List.of(new Ulimit("nofile", 30_000L, 30_000L))));
     }
 
     public String getSchemaRegistryUrl() {


### PR DESCRIPTION
Docker containers we use in the integration tests need a higher open file limit.

Similar PR for S3: https://github.com/aiven/s3-connector-for-apache-kafka/pull/216