### PR TITLE
Replace deprecated classes with Wrapper#getDistributionUrl()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 
-import org.gradle.util.DistributionLocator
-import org.gradle.util.GradleVersion
-
 plugins {
     // https://docs.gradle.org/current/userguide/java_library_plugin.html
     id "java-library"
@@ -65,10 +62,7 @@ java {
 wrapper {
     distributionType = 'ALL'
     doLast {
-        final DistributionLocator locator = new DistributionLocator()
-        final GradleVersion version = GradleVersion.version(wrapper.gradleVersion)
-        final URI distributionUri = locator.getDistributionFor(version, wrapper.distributionType.name().toLowerCase(Locale.ENGLISH))
-        final URI sha256Uri = new URI(distributionUri.toString() + ".sha256")
+        final URI sha256Uri = new URI(wrapper.getDistributionUrl() + ".sha256")
         final String sha256Sum = new String(sha256Uri.toURL().bytes)
         wrapper.getPropertiesFile() << "distributionSha256Sum=${sha256Sum}\n"
         println "Added checksum to wrapper properties"


### PR DESCRIPTION
Class org.gradle.util.DistributionLocator and based on its javadoc comment it will be removed in gradle 8.0

The PR replaces usage of this class with Wrapper#getDistributionUrl() which under the hood has same logic.