### PR TITLE
Clearing record grouper on exceptions to avoid duplicates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ ext {
     aivenConnectCommonsVersion = "0.8.2"
     testcontainersVersion = "1.17.5"
     slf4jVersion = "1.7.36"
+    wireMockVersion = "2.35.0"
 }
 
 distributions {
@@ -176,6 +177,7 @@ dependencies {
     integrationTestImplementation "org.apache.avro:avro:1.11.1"
 
     integrationTestImplementation "io.aiven:commons-for-apache-kafka-connect:$aivenConnectCommonsVersion"
+    integrationTestImplementation "com.github.tomakehurst:wiremock-jre8:$wireMockVersion"
 
     testImplementation ("org.apache.parquet:parquet-tools:1.11.2") {
         exclude group: "org.slf4j", module: "slf4j-api"

--- a/src/integration-test/java/io/aiven/kafka/connect/gcs/AbstractIntegrationTest.java
+++ b/src/integration-test/java/io/aiven/kafka/connect/gcs/AbstractIntegrationTest.java
@@ -42,6 +42,8 @@ class AbstractIntegrationTest {
 
     protected static final int OFFSET_FLUSH_INTERVAL_MS = 5000;
 
+    protected static final String DEFAULT_GCS_ENDPOINT = "https://storage.googleapis.com";
+
     protected static String gcsCredentialsPath; // NOPMD mutable static state
     protected static String gcsCredentialsJson; // NOPMD mutable static state
 

--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkConfig.java
@@ -51,6 +51,7 @@ public final class GcsSinkConfig extends AivenCommonConfig {
 
     private static final String GROUP_GCS = "GCS";
     public static final String GCS_CREDENTIALS_PATH_CONFIG = "gcs.credentials.path";
+    public static final String GCS_ENDPOINT_CONFIG = "gcs.endpoint";
     public static final String GCS_CREDENTIALS_JSON_CONFIG = "gcs.credentials.json";
     public static final String GCS_BUCKET_NAME_CONFIG = "gcs.bucket.name";
 
@@ -102,6 +103,9 @@ public final class GcsSinkConfig extends AivenCommonConfig {
 
     private static void addGcsConfigGroup(final ConfigDef configDef) {
         int gcsGroupCounter = 0;
+        configDef.define(GCS_ENDPOINT_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW,
+                "Explicit GCS Endpoint Address, mainly for testing", GROUP_GCS, gcsGroupCounter++, ConfigDef.Width.NONE,
+                GCS_ENDPOINT_CONFIG);
         configDef.define(GCS_CREDENTIALS_PATH_CONFIG, ConfigDef.Type.STRING, null, ConfigDef.Importance.LOW,
                 "The path to a GCP credentials file. "
                         + "If not provided, the connector will try to detect the credentials automatically. "
@@ -388,4 +392,7 @@ public final class GcsSinkConfig extends AivenCommonConfig {
         return Duration.ofMillis(getLong(GCS_RETRY_BACKOFF_MAX_DELAY_MS_CONFIG));
     }
 
+    public String getGcsEndpoint() {
+        return getString(GCS_ENDPOINT_CONFIG);
+    }
 }

--- a/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkTask.java
+++ b/src/main/java/io/aiven/kafka/connect/gcs/GcsSinkTask.java
@@ -70,6 +70,7 @@ public final class GcsSinkTask extends SinkTask {
 
         this.config = new GcsSinkConfig(props);
         this.storage = StorageOptions.newBuilder()
+                .setHost(config.getGcsEndpoint())
                 .setCredentials(config.getCredentials())
                 .setRetrySettings(RetrySettings.newBuilder()
                         .setInitialRetryDelay(config.getGcsRetryBackoffInitialDelay())
@@ -106,8 +107,11 @@ public final class GcsSinkTask extends SinkTask {
 
     @Override
     public void flush(final Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
-        recordGrouper.records().forEach(this::flushFile);
-        recordGrouper.clear();
+        try {
+            recordGrouper.records().forEach(this::flushFile);
+        } finally {
+            recordGrouper.clear();
+        }
     }
 
     private void flushFile(final String filename, final List<SinkRecord> records) {


### PR DESCRIPTION
When the exception is thrown during flush(e.g. network error), Kafka connects rewinds the offsets to last committed and tries to commit current offsets once again. This causes duplicates in the connector since the offsets are now cached in record grouper. Cleaning the record grouper on exception solves the issues.