### PR TITLE
chore: use distribution for Java setup in GH Action

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/setup-java@v3.11.0
         with:
           java-version: 11
+          distribution: 'temurin'
 
       - name: Checkout code
         uses: actions/checkout@v3.5.2


### PR DESCRIPTION
The distribution is a required parameter for `setup-java` action.